### PR TITLE
feat(sim): add Sensors+Imu systems to simulation worlds

### DIFF
--- a/worlds/obstacle_course.sdf
+++ b/worlds/obstacle_course.sdf
@@ -13,6 +13,12 @@
     <plugin filename="libignition-gazebo-user-commands-system.so" name="ignition::gazebo::systems::UserCommands"/>
     <plugin filename="libignition-gazebo-scene-broadcaster-system.so" name="ignition::gazebo::systems::SceneBroadcaster"/>
     <plugin filename="libignition-gazebo-contact-system.so" name="ignition::gazebo::systems::Contact"/>
+    <!-- Rendering sensors (camera, gpu_lidar) require the Sensors system + a render engine. -->
+    <plugin filename="libignition-gazebo-sensors-system.so" name="ignition::gazebo::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <!-- IMU sensors require the Imu system. -->
+    <plugin filename="libignition-gazebo-imu-system.so" name="ignition::gazebo::systems::Imu"/>
 
     <!-- Scene -->
     <scene>

--- a/worlds/simple_test.sdf
+++ b/worlds/simple_test.sdf
@@ -13,6 +13,12 @@
     <plugin filename="libignition-gazebo-user-commands-system.so" name="ignition::gazebo::systems::UserCommands"/>
     <plugin filename="libignition-gazebo-scene-broadcaster-system.so" name="ignition::gazebo::systems::SceneBroadcaster"/>
     <plugin filename="libignition-gazebo-contact-system.so" name="ignition::gazebo::systems::Contact"/>
+    <!-- Rendering sensors (camera, gpu_lidar) require the Sensors system + a render engine. -->
+    <plugin filename="libignition-gazebo-sensors-system.so" name="ignition::gazebo::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <!-- IMU sensors require the Imu system. -->
+    <plugin filename="libignition-gazebo-imu-system.so" name="ignition::gazebo::systems::Imu"/>
 
     <!-- Scene -->
     <scene>

--- a/worlds/sock_arena.sdf
+++ b/worlds/sock_arena.sdf
@@ -13,6 +13,12 @@
     <plugin filename="libignition-gazebo-user-commands-system.so" name="ignition::gazebo::systems::UserCommands"/>
     <plugin filename="libignition-gazebo-scene-broadcaster-system.so" name="ignition::gazebo::systems::SceneBroadcaster"/>
     <plugin filename="libignition-gazebo-contact-system.so" name="ignition::gazebo::systems::Contact"/>
+    <!-- Rendering sensors (camera, gpu_lidar) require the Sensors system + a render engine. -->
+    <plugin filename="libignition-gazebo-sensors-system.so" name="ignition::gazebo::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+    </plugin>
+    <!-- IMU sensors require the Imu system. -->
+    <plugin filename="libignition-gazebo-imu-system.so" name="ignition::gazebo::systems::Imu"/>
 
     <!-- Scene -->
     <scene>


### PR DESCRIPTION
Full Gazebo Fortress simulation enablement for the JeTank: all components testable in sim (base drive, lidar /scan, IMU, stereo camera, MoveIt arm). Verified end-to-end (sensors publish, SLAM map builds, MoveIt plans+executes the arm). See jetank_simulation/SIM_TESTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)