### PR TITLE
fix(sim): Fortress GUI render stack in worlds

### DIFF
--- a/worlds/obstacle_course.sdf
+++ b/worlds/obstacle_course.sdf
@@ -30,7 +30,8 @@
 
     <!-- GUI -->
     <gui fullscreen="0">
-      <plugin filename="GzScene3D" name="3D View">
+      <!-- Fortress render stack (GzScene3D is deprecated → blank GUI). -->
+      <plugin filename="MinimalScene" name="3D View">
         <ignition-gui>
           <title>3D View</title>
           <property type="bool" key="showTitleBar">false</property>
@@ -42,6 +43,9 @@
         <background_color>0.8 0.8 0.8</background_color>
         <camera_pose>0 -6 4 0 0.5 1.5708</camera_pose>
       </plugin>
+      <plugin filename="GzSceneManager" name="Scene Manager"/>
+      <plugin filename="InteractiveViewControl" name="Interactive view control"/>
+      <plugin filename="CameraTracking" name="Camera Tracking"/>
 
       <plugin filename="WorldControl" name="World control">
         <ignition-gui>

--- a/worlds/simple_test.sdf
+++ b/worlds/simple_test.sdf
@@ -30,7 +30,8 @@
 
     <!-- GUI -->
     <gui fullscreen="0">
-      <plugin filename="GzScene3D" name="3D View">
+      <!-- Fortress render stack (GzScene3D is deprecated → blank GUI). -->
+      <plugin filename="MinimalScene" name="3D View">
         <ignition-gui>
           <title>3D View</title>
           <property type="bool" key="showTitleBar">false</property>
@@ -42,6 +43,9 @@
         <background_color>0.8 0.8 0.8</background_color>
         <camera_pose>-2 -2 1.5 0 0.3 0.785</camera_pose>
       </plugin>
+      <plugin filename="GzSceneManager" name="Scene Manager"/>
+      <plugin filename="InteractiveViewControl" name="Interactive view control"/>
+      <plugin filename="CameraTracking" name="Camera Tracking"/>
 
       <plugin filename="WorldControl" name="World control">
         <ignition-gui>

--- a/worlds/sock_arena.sdf
+++ b/worlds/sock_arena.sdf
@@ -30,7 +30,8 @@
 
     <!-- GUI -->
     <gui fullscreen="0">
-      <plugin filename="GzScene3D" name="3D View">
+      <!-- Fortress render stack (GzScene3D is deprecated → blank GUI). -->
+      <plugin filename="MinimalScene" name="3D View">
         <ignition-gui>
           <title>3D View</title>
           <property type="bool" key="showTitleBar">false</property>
@@ -42,6 +43,9 @@
         <background_color>0.8 0.8 0.8</background_color>
         <camera_pose>0 -5 3 0 0.4 1.5708</camera_pose>
       </plugin>
+      <plugin filename="GzSceneManager" name="Scene Manager"/>
+      <plugin filename="InteractiveViewControl" name="Interactive view control"/>
+      <plugin filename="CameraTracking" name="Camera Tracking"/>
 
       <plugin filename="WorldControl" name="World control">
         <ignition-gui>


### PR DESCRIPTION
GzScene3D → MinimalScene+GzSceneManager+InteractiveViewControl in simple_test/obstacle_course/sock_arena so the GUI renders on gz-sim6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)